### PR TITLE
Add hint command

### DIFF
--- a/cmd/hint.go
+++ b/cmd/hint.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
+	"github.com/gsamokovarov/jump/scoring"
+)
+
+func hintCmd(args cli.Args, conf *config.Config) {
+	if len(args) == 0 {
+		return
+	}
+
+	entries, err := conf.ReadEntries()
+	if err != nil {
+		cli.Exitf(1, "%s\n", err)
+	}
+
+	fuzzyEntries := scoring.NewFuzzyEntries(entries, args.CommandName())
+	fuzzyEntries.Sort()
+	for _, entry := range fuzzyEntries.Entries {
+		cli.Outf("%s\n", entry.Path)
+	}
+}
+
+func init() {
+	cli.RegisterCommand("hint", "Hints relevant paths for jumping.", hintCmd)
+}


### PR DESCRIPTION
Add command for showing related path completions. This could be useful in shell completion script or just as is.

Example: `j hint dev`