### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gsamokovarov/jump
+
+require github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335 h1:MFE3iUApg9Sl5MmZnosCEhYXRQCKz5coShpoAF86IiE=
+github.com/gsamokovarov/assert v0.0.0-20180414063448-8cd8ab63a335/go.mod h1:ejyiK4+/RLW9C/QgBK+nlwDmNB9pIW9i2WVqMmAa7no=


### PR DESCRIPTION
This allows building and testing outside of the go path if a developer
has go1.11 installed.

It's also nice to keep up with the ecosystem.