### PR TITLE
Respect $HOME for config location

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,10 +71,24 @@ func normalizeDir(dir string) (string, error) {
 		return dir, nil
 	}
 
-	usr, err := user.Current()
+	home, err := homeDir()
 	if err != nil {
 		return dir, err
 	}
 
-	return filepath.Join(usr.HomeDir, defaultDirName), nil
+	return filepath.Join(home, defaultDirName), nil
+}
+
+// See https://github.com/golang/go/issues/26463
+func homeDir() (string, error) {
+	home := os.Getenv("HOME")
+	if home != "" {
+		return home, nil
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return usr.HomeDir, nil
 }


### PR DESCRIPTION
As discussed in https://github.com/golang/go/issues/26463, Go's
'user.Current().HomeDir' does not do the right thing.
The 'HOME' environment variable is meant to take precedent over
whatever's in /etc/passwd.

This updates the config directory initialization code to use the correct
home directory.