### PR TITLE
Introduce autojump and z configuration importers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.11
   - master
 
 script:
@@ -12,3 +12,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - go: master
+
+env:
+  global:
+    - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ To trigger a case-sensitive search, use a term that has a capital letter.
 The jump will resolve to `/Users/genadi/Development` even if there is
 `/Users/genadi/Development/dev-tools` that scores better.
 
+## Is it like autojump or z?
+
+Yes, it is! You can import your datafile from `autojump` or `z` with:
+
+```bash
+$ jump import
+```
+
+This will try `z` first then `autojump`, so you can even combine all the
+entries from both tools.
+
+The command is safe to run on pre-existing jump database, because if an entry
+exist in jump already, it won't be imported and it's score will remain
+unchanged. You can be explicit and choose to import `autojump` or `z` with:
+
+```bash
+$ jump import autojump
+$ jump import z
+```
+
 ## Installation
 
 Jump comes in packages for macOS through homebrew and linux.

--- a/cmd/cd_test.go
+++ b/cmd/cd_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	s "github.com/gsamokovarov/jump/scoring"
 )
 
 func Test_cdCmd(t *testing.T) {
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p.Join(td, "web-console"), &s.Score{Weight: 100, Age: s.Now}},
 			&s.Entry{p.Join(td, "/client/website"), &s.Score{Weight: 90, Age: s.Now}},
@@ -27,7 +28,7 @@ func Test_cdCmd(t *testing.T) {
 }
 
 func Test_cdCmd_noEntries(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 
 	output := capture(&os.Stderr, func() {
 		assert.Nil(t, cdCmd(cli.Args{"wc"}, conf))
@@ -37,7 +38,7 @@ func Test_cdCmd_noEntries(t *testing.T) {
 }
 
 func Test_cdCmd_multipleArgumentsAsSeparators(t *testing.T) {
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p.Join(td, "web-console"), &s.Score{Weight: 100, Age: s.Now}},
 			&s.Entry{p.Join(td, "/client/website"), &s.Score{Weight: 90, Age: s.Now}},
@@ -52,7 +53,7 @@ func Test_cdCmd_multipleArgumentsAsSeparators(t *testing.T) {
 }
 
 func Test_cdCmd_absolutePath(t *testing.T) {
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p.Join(td, "web-console"), &s.Score{Weight: 100, Age: s.Now}},
 			&s.Entry{p.Join(td, "/client/website"), &s.Score{Weight: 90, Age: s.Now}},
@@ -71,7 +72,7 @@ func Test_cdCmd_exactMatch(t *testing.T) {
 	p2 := p.Join(td, "/client/website")
 	p3 := p.Join(td, "web")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p1, &s.Score{Weight: 100, Age: s.Now}},
 			&s.Entry{p2, &s.Score{Weight: 90, Age: s.Now}},

--- a/cmd/chdir_test.go
+++ b/cmd/chdir_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 )
 
 func Test_chdirCmd(t *testing.T) {
 	p1 := p.Join(td, "web-console")
 	p2 := p.Join(td, "/client/website")
 
-	conf := &testConfig{}
+	conf := &config.Testing{}
 
 	entries, err := conf.ReadEntries()
 	assert.Nil(t, err)
@@ -47,7 +48,7 @@ func Test_chdirCmd(t *testing.T) {
 }
 
 func Test_chdirCmd_cwd(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 
 	entries, err := conf.ReadEntries()
 	assert.Nil(t, err)

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 )
 
 func Test_cleanCmd(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 
 	assert.Nil(t, chdirCmd(cli.Args{"/inexistent/dir/dh891n2kisdha"}, conf))
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -4,56 +4,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-
-	"github.com/gsamokovarov/jump/config"
-	"github.com/gsamokovarov/jump/scoring"
 )
 
 var td string
-
-type testConfig struct {
-	Entries scoring.Entries
-	Search  config.Search
-	Pins    map[string]string
-	Pin     string
-}
-
-func (c *testConfig) ReadEntries() (scoring.Entries, error) {
-	return c.Entries, nil
-}
-
-func (c *testConfig) WriteEntries(entries scoring.Entries) error {
-	c.Entries = entries
-	return nil
-}
-
-func (c *testConfig) ReadSearch() config.Search {
-	return c.Search
-}
-
-func (c *testConfig) WriteSearch(term string, index int) error {
-	c.Search.Term = term
-	c.Search.Index = index
-	return nil
-}
-
-func (c *testConfig) ReadPins() (map[string]string, error) {
-	return c.Pins, nil
-}
-
-func (c *testConfig) FindPin(term string) (string, bool) {
-	return c.Pin, c.Pin != ""
-}
-
-func (c *testConfig) WritePin(_, value string) error {
-	c.Pin = value
-	return nil
-}
-
-func (c *testConfig) RemovePin(term string) error {
-	c.Pin = ""
-	return nil
-}
 
 func capture(stream **os.File, fn func()) string {
 	rescue := *stream

--- a/cmd/forget_test.go
+++ b/cmd/forget_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	"github.com/gsamokovarov/jump/scoring"
 )
 
 func Test_forgetCmd(t *testing.T) {
 	p := p.Join(td, "web-console")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: scoring.Entries{scoring.NewEntry(p)},
 	}
 

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -18,6 +18,7 @@ func Example_helpCmd() {
 	//   clean        Cleans the database of inexisting entries.
 	//   forget       Removes the current directory from the database.
 	//   hint         Hints relevant paths for jumping.
+	//   import       Import autojump or z scores.
 	//   pin          Pin a directory to a search term.
 	//   pins         Lists all the pinned search terms.
 	//   shell        Display a shell integration script.

--- a/cmd/hint_test.go
+++ b/cmd/hint_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	s "github.com/gsamokovarov/jump/scoring"
 )
 
@@ -15,7 +16,7 @@ func Test_hintCmd_short(t *testing.T) {
 	p1 := p.Join(td, "web-console")
 	p2 := p.Join(td, "/client/website")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p2, &s.Score{Weight: 90, Age: s.Now}},
 			&s.Entry{p1, &s.Score{Weight: 100, Age: s.Now}},
@@ -33,7 +34,7 @@ func Test_hintCmd_short(t *testing.T) {
 }
 
 func Test_hintCmd_noEntries(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 
 	output := capture(&os.Stdout, func() {
 		assert.Nil(t, hintCmd(cli.Args{"webcons"}, conf))

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
+	"github.com/gsamokovarov/jump/importer"
+	"github.com/gsamokovarov/jump/scoring"
+)
+
+func importCmd(args cli.Args, conf config.Config) error {
+	imp := importer.Autojump(conf)
+
+	return imp.Import(func(entry *scoring.Entry) {
+		cli.Outf("Importing %s\n", entry.Path)
+	})
+}
+
+func init() {
+	cli.RegisterCommand("import", "Import autojump or z scores.", importCmd)
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -8,7 +8,7 @@ import (
 )
 
 func importCmd(args cli.Args, conf config.Config) error {
-	imp := importer.Autojump(conf)
+	imp := importer.Guess(args.CommandName(), conf)
 
 	return imp.Import(func(entry *scoring.Entry) {
 		cli.Outf("Importing %s\n", entry.Path)

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gsamokovarov/assert"
+	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
+)
+
+func Test_importCmd_autojump(t *testing.T) {
+	oldHOME := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHOME)
+
+	os.Setenv("HOME", td)
+
+	conf := &config.Testing{}
+
+	output := capture(&os.Stdout, func() {
+		assert.Nil(t, importCmd(cli.Args{"autojump"}, conf))
+	})
+
+	assert.Equal(t, `Importing /Users/genadi/Development/jump
+Importing /Users/genadi/Development/mock_last_status
+Importing /Users/genadi/Development
+Importing /Users/genadi/.go/src/github.com/gsamokovarov/jump
+Importing /usr/local/Cellar/autojump
+Importing /Users/genadi/Development/gloat
+`, output)
+
+	assert.Len(t, 6, conf.Entries)
+}
+
+func Test_importCmd_z(t *testing.T) {
+	oldHOME := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHOME)
+
+	os.Setenv("HOME", td)
+
+	conf := &config.Testing{}
+
+	output := capture(&os.Stdout, func() {
+		assert.Nil(t, importCmd(cli.Args{"z"}, conf))
+	})
+
+	assert.Equal(t, `Importing /Users/genadi/Development/hack
+Importing /Users/genadi/Development/masse
+Importing /Users/genadi/Development
+Importing /Users/genadi/.go/src/github.com/gsamokovarov/jump
+`, output)
+
+	assert.Len(t, 4, conf.Entries)
+}
+
+func Test_importCmd_itALL(t *testing.T) {
+	oldHOME := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHOME)
+
+	os.Setenv("HOME", td)
+
+	conf := &config.Testing{}
+
+	output := capture(&os.Stdout, func() {
+		assert.Nil(t, importCmd(cli.Args{""}, conf))
+	})
+
+	assert.Equal(t, `Importing /Users/genadi/Development/hack
+Importing /Users/genadi/Development/masse
+Importing /Users/genadi/Development
+Importing /Users/genadi/.go/src/github.com/gsamokovarov/jump
+Importing /Users/genadi/Development/jump
+Importing /Users/genadi/Development/mock_last_status
+Importing /usr/local/Cellar/autojump
+Importing /Users/genadi/Development/gloat
+`, output)
+
+	assert.Len(t, 8, conf.Entries)
+}

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	s "github.com/gsamokovarov/jump/scoring"
 )
 
@@ -14,7 +15,7 @@ func Test_pinCmd(t *testing.T) {
 	p1 := p.Join(td, "web")
 	p2 := p.Join(td, "web-console")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p2, &s.Score{Weight: 1, Age: s.Now}},
 			&s.Entry{p1, &s.Score{Weight: 100, Age: s.Now}},
@@ -34,7 +35,7 @@ func Test_pinCmd_normalizedTerms(t *testing.T) {
 	p1 := p.Join(td, "web")
 	p2 := p.Join(td, "web-console")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p2, &s.Score{Weight: 1, Age: s.Now}},
 			&s.Entry{p1, &s.Score{Weight: 100, Age: s.Now}},

--- a/cmd/pins_test.go
+++ b/cmd/pins_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/gsamokovarov/assert"
+	"github.com/gsamokovarov/jump/config"
 )
 
 func Test_pinsCmd(t *testing.T) {
-	conf := &testConfig{
+	conf := &config.Testing{
 		Pins: map[string]string{
 			"r": "/home/user/projects/rails",
 		},

--- a/cmd/testdata/.local/share/autojump/autojump.txt
+++ b/cmd/testdata/.local/share/autojump/autojump.txt
@@ -1,0 +1,6 @@
+38.729833462	/Users/genadi/Development/jump
+14.1421356237	/Users/genadi/Development/mock_last_status
+33.1662479035	/Users/genadi/Development
+14.1421356237	/Users/genadi/.go/src/github.com/gsamokovarov/jump
+43.5889894353	/usr/local/Cellar/autojump
+20.0	/Users/genadi/Development/gloat

--- a/cmd/testdata/.z
+++ b/cmd/testdata/.z
@@ -1,0 +1,4 @@
+/Users/genadi/Development/hack|11|1536272816
+/Users/genadi/Development/masse|1|1536272502
+/Users/genadi/Development|3|1536272506
+/Users/genadi/.go/src/github.com/gsamokovarov/jump|1|1536272492

--- a/cmd/top_test.go
+++ b/cmd/top_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	s "github.com/gsamokovarov/jump/scoring"
 )
 
@@ -15,7 +16,7 @@ func Test_topCmd(t *testing.T) {
 	wc := p.Join(td, "web-console")
 	web := p.Join(td, "/client/website")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{wc, &s.Score{Weight: 100, Age: s.Now}},
 			&s.Entry{web, &s.Score{Weight: 90, Age: s.Now}},

--- a/cmd/unpin_test.go
+++ b/cmd/unpin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/cli"
+	"github.com/gsamokovarov/jump/config"
 	s "github.com/gsamokovarov/jump/scoring"
 )
 
@@ -14,7 +15,7 @@ func Test_unpinCmd(t *testing.T) {
 	p1 := p.Join(td, "web")
 	p2 := p.Join(td, "web-console")
 
-	conf := &testConfig{
+	conf := &config.Testing{
 		Entries: s.Entries{
 			&s.Entry{p2, &s.Score{Weight: 1, Age: s.Now}},
 			&s.Entry{p1, &s.Score{Weight: 100, Age: s.Now}},

--- a/config/testing.go
+++ b/config/testing.go
@@ -1,0 +1,58 @@
+package config
+
+import "github.com/gsamokovarov/jump/scoring"
+
+// Testing is an in-memory testing config which loosely follows the default
+// file-based configuration behavior.
+type Testing struct {
+	Entries scoring.Entries
+	Search  Search
+	Pins    map[string]string
+	Pin     string
+}
+
+// ReadEntries implements the Config interface.
+func (c *Testing) ReadEntries() (scoring.Entries, error) {
+	return c.Entries, nil
+}
+
+// WriteEntries implements the Config interface.
+func (c *Testing) WriteEntries(entries scoring.Entries) error {
+	c.Entries = entries
+	c.Entries.Sort()
+	return nil
+}
+
+// ReadSearch implements the Config interface.
+func (c *Testing) ReadSearch() Search {
+	return c.Search
+}
+
+// WriteSearch implements the Config interface.
+func (c *Testing) WriteSearch(term string, index int) error {
+	c.Search.Term = term
+	c.Search.Index = index
+	return nil
+}
+
+// ReadPins implements the Config interface.
+func (c *Testing) ReadPins() (map[string]string, error) {
+	return c.Pins, nil
+}
+
+// FindPin implements the Config interface.
+func (c *Testing) FindPin(term string) (string, bool) {
+	return c.Pin, c.Pin != ""
+}
+
+// WritePin implements the Config interface.
+func (c *Testing) WritePin(_, value string) error {
+	c.Pin = value
+	return nil
+}
+
+// RemovePin implements the Config interface.
+func (c *Testing) RemovePin(term string) error {
+	c.Pin = ""
+	return nil
+}

--- a/importer/autojump.go
+++ b/importer/autojump.go
@@ -1,0 +1,106 @@
+package importer
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/gsamokovarov/jump/config"
+	"github.com/gsamokovarov/jump/scoring"
+)
+
+var autojumpDefaultConfigPaths = []string{
+	"$HOME/.local/share/autojump/autojump.txt",
+	"$HOME/Library/autojump/autojump.txt",
+}
+
+// Autojump is an importer for the autojump tool.
+func Autojump(conf config.Config, configPaths ...string) Importer {
+	if len(configPaths) == 0 {
+		configPaths = autojumpDefaultConfigPaths
+	}
+
+	return &autojump{
+		config:      conf,
+		configPaths: configPaths,
+	}
+}
+
+type autojump struct {
+	config      config.Config
+	configPaths []string
+}
+
+func (i *autojump) Import(fn Callback) error {
+	autojumpEntries, err := i.parseConfig()
+	if err != nil {
+		return err
+	}
+
+	jumpEntries, err := i.config.ReadEntries()
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range autojumpEntries {
+		if _, found := jumpEntries.Find(entry.Path); found {
+			continue
+		}
+
+		if fn != nil {
+			fn(entry)
+		}
+
+		jumpEntries = append(jumpEntries, entry)
+	}
+
+	return i.config.WriteEntries(jumpEntries)
+}
+
+func (i *autojump) parseConfig() (scoring.Entries, error) {
+	content, err := readConfig(i.configPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries scoring.Entries
+
+	for _, line := range strings.Split(content, "\n") {
+		entry, err := i.newEntryFromLine(line)
+		if err == io.EOF {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if _, found := entries.Find(entry.Path); found {
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func (i *autojump) newEntryFromLine(line string) (*scoring.Entry, error) {
+	if line == "" {
+		return nil, io.EOF
+	}
+
+	parts := strings.Split(line, "\t")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("importer: cannot parse entry: %s", line)
+	}
+
+	path := parts[1]
+	weight, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	return scoring.NewEntryWithWeight(path, int64(math.Round(weight))), nil
+}

--- a/importer/autojump.go
+++ b/importer/autojump.go
@@ -49,9 +49,7 @@ func (i *autojump) Import(fn Callback) error {
 			continue
 		}
 
-		if fn != nil {
-			fn(entry)
-		}
+		fn.Call(entry)
 
 		jumpEntries = append(jumpEntries, entry)
 	}

--- a/importer/autojump_test.go
+++ b/importer/autojump_test.go
@@ -19,21 +19,25 @@ func TestAutojump(t *testing.T) {
 	assert.
 		Len(t, 6, conf.Entries).
 		// 0
-		Equal(t, "/Users/genadi/Development/jump", conf.Entries[0].Path).
-		Equal(t, 39, conf.Entries[0].Score.Weight).
+		Equal(t, "/Users/genadi/Development/mock_last_status", conf.Entries[0].Path).
+		Equal(t, 14, conf.Entries[0].Score.Weight).
 		// 1
-		Equal(t, "/Users/genadi/Development/mock_last_status", conf.Entries[1].Path).
+		Equal(t, "/Users/genadi/.go/src/github.com/gsamokovarov/jump", conf.Entries[1].Path).
 		Equal(t, 14, conf.Entries[1].Score.Weight).
 		// 2
-		Equal(t, "/Users/genadi/Development", conf.Entries[2].Path).
-		Equal(t, 33, conf.Entries[2].Score.Weight).
+		Equal(t, "/Users/genadi/Development/gloat", conf.Entries[2].Path).
+		Equal(t, 20, conf.Entries[2].Score.Weight).
 		// 3
-		Equal(t, "/Users/genadi/.go/src/github.com/gsamokovarov/jump", conf.Entries[3].Path).
-		Equal(t, 14, conf.Entries[3].Score.Weight).
+		Equal(t, "/Users/genadi/Development", conf.Entries[3].Path).
+		Equal(t, 33, conf.Entries[3].Score.Weight).
 		// 4
-		Equal(t, "/usr/local/Cellar/autojump", conf.Entries[4].Path).
-		Equal(t, 44, conf.Entries[4].Score.Weight).
+		Equal(t, "/Users/genadi/Development/jump", conf.Entries[4].Path).
+		Equal(t, 39, conf.Entries[4].Score.Weight).
 		// 5
-		Equal(t, "/Users/genadi/Development/gloat", conf.Entries[5].Path).
-		Equal(t, 20, conf.Entries[5].Score.Weight)
+		Equal(t, "/usr/local/Cellar/autojump", conf.Entries[5].Path).
+		Equal(t, 44, conf.Entries[5].Score.Weight)
+
+	for i, j := 0, 1; i < len(conf.Entries)-1; i, j = i+1, j+1 {
+		assert.True(t, conf.Entries[i].CalculateScore() <= conf.Entries[j].CalculateScore())
+	}
 }

--- a/importer/autojump_test.go
+++ b/importer/autojump_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/gsamokovarov/assert"
+	"github.com/gsamokovarov/jump/config"
 )
 
 func TestAutojump(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 	configPath := p.Join(td, "autojump.txt")
 
 	imp := Autojump(conf, configPath)

--- a/importer/autojump_test.go
+++ b/importer/autojump_test.go
@@ -1,0 +1,39 @@
+package importer
+
+import (
+	p "path"
+	"testing"
+
+	"github.com/gsamokovarov/assert"
+)
+
+func TestAutojump(t *testing.T) {
+	conf := &testConfig{}
+	configPath := p.Join(td, "autojump.txt")
+
+	imp := Autojump(conf, configPath)
+
+	err := imp.Import(nil)
+	assert.Nil(t, err)
+
+	assert.
+		Len(t, 6, conf.Entries).
+		// 0
+		Equal(t, "/Users/genadi/Development/jump", conf.Entries[0].Path).
+		Equal(t, 39, conf.Entries[0].Score.Weight).
+		// 1
+		Equal(t, "/Users/genadi/Development/mock_last_status", conf.Entries[1].Path).
+		Equal(t, 14, conf.Entries[1].Score.Weight).
+		// 2
+		Equal(t, "/Users/genadi/Development", conf.Entries[2].Path).
+		Equal(t, 33, conf.Entries[2].Score.Weight).
+		// 3
+		Equal(t, "/Users/genadi/.go/src/github.com/gsamokovarov/jump", conf.Entries[3].Path).
+		Equal(t, 14, conf.Entries[3].Score.Weight).
+		// 4
+		Equal(t, "/usr/local/Cellar/autojump", conf.Entries[4].Path).
+		Equal(t, 44, conf.Entries[4].Score.Weight).
+		// 5
+		Equal(t, "/Users/genadi/Development/gloat", conf.Entries[5].Path).
+		Equal(t, 20, conf.Entries[5].Score.Weight)
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gsamokovarov/jump/scoring"
 )
 
-// UnsupportedErr is an error returned when the importing tool is not found.
-var UnsupportedErr = errors.New("importer: unsupported")
+// NotFoundErr is an error returned when the importing tool is not found.
+var NotFoundErr = errors.New("importer: cannot find autojump or z data files")
 
 // Callback is called on every import.
 type Callback func(*scoring.Entry)
@@ -67,5 +67,5 @@ func findPath(paths []string) (string, error) {
 		}
 	}
 
-	return "", UnsupportedErr
+	return "", NotFoundErr
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/gsamokovarov/jump/config"
 	"github.com/gsamokovarov/jump/scoring"
 )
 
@@ -17,6 +18,23 @@ type Callback func(*scoring.Entry)
 // Importer imports a configuration from an external tool into jump.
 type Importer interface {
 	Import(fn Callback) error
+}
+
+// Guess tries to guess the importer to use based on a hint.
+func Guess(hint string, conf config.Config) Importer {
+	var imp Importer
+
+	switch hint {
+	case "autojump":
+		imp = Autojump(conf)
+	case "z":
+		imp = Z(conf)
+	default:
+		// First try z, then try autojump.
+		imp = multiImporter{Z(conf), Autojump(conf)}
+	}
+
+	return imp
 }
 
 func readConfig(paths []string) (string, error) {

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -15,6 +15,13 @@ var UnsupportedErr = errors.New("importer: unsupported")
 // Callback is called on every import.
 type Callback func(*scoring.Entry)
 
+// Call calls the callback without the need of nil checks.
+func (fn Callback) Call(entry *scoring.Entry) {
+	if fn != nil {
+		fn(entry)
+	}
+}
+
 // Importer imports a configuration from an external tool into jump.
 type Importer interface {
 	Import(fn Callback) error

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -1,0 +1,46 @@
+package importer
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/gsamokovarov/jump/scoring"
+)
+
+// UnsupportedErr is an error returned when the importing tool is not found.
+var UnsupportedErr = errors.New("importer: unsupported")
+
+// Callback is called on every import.
+type Callback func(*scoring.Entry)
+
+// Importer imports a configuration from an external tool into jump.
+type Importer interface {
+	Import(fn Callback) error
+}
+
+func readConfig(paths []string) (string, error) {
+	path, err := findPath(paths)
+	if err != nil {
+		return "", err
+	}
+
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
+func findPath(paths []string) (string, error) {
+	for _, path := range paths {
+		path = os.ExpandEnv(path)
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			return path, nil
+		}
+	}
+
+	return "", UnsupportedErr
+}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -3,7 +3,9 @@ package importer
 import (
 	"os"
 	"path"
+	"testing"
 
+	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/config"
 	"github.com/gsamokovarov/jump/scoring"
 )
@@ -23,6 +25,7 @@ func (c *testConfig) ReadEntries() (scoring.Entries, error) {
 
 func (c *testConfig) WriteEntries(entries scoring.Entries) error {
 	c.Entries = entries
+	c.Entries.Sort()
 	return nil
 }
 
@@ -52,6 +55,27 @@ func (c *testConfig) WritePin(_, value string) error {
 func (c *testConfig) RemovePin(term string) error {
 	c.Pin = ""
 	return nil
+}
+
+func TestGuess_Autojump(t *testing.T) {
+	imp := Guess("autojump", &testConfig{})
+
+	_, ok := imp.(*autojump)
+	assert.True(t, ok)
+}
+
+func TestGuess_Z(t *testing.T) {
+	imp := Guess("z", &testConfig{})
+
+	_, ok := imp.(*z)
+	assert.True(t, ok)
+}
+
+func TestGuess_Both(t *testing.T) {
+	imp := Guess("", &testConfig{})
+
+	_, ok := imp.(multiImporter)
+	assert.True(t, ok)
 }
 
 func init() {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -7,72 +7,26 @@ import (
 
 	"github.com/gsamokovarov/assert"
 	"github.com/gsamokovarov/jump/config"
-	"github.com/gsamokovarov/jump/scoring"
 )
 
 var td string
 
-type testConfig struct {
-	Entries scoring.Entries
-	Search  config.Search
-	Pins    map[string]string
-	Pin     string
-}
-
-func (c *testConfig) ReadEntries() (scoring.Entries, error) {
-	return c.Entries, nil
-}
-
-func (c *testConfig) WriteEntries(entries scoring.Entries) error {
-	c.Entries = entries
-	c.Entries.Sort()
-	return nil
-}
-
-func (c *testConfig) ReadSearch() config.Search {
-	return c.Search
-}
-
-func (c *testConfig) WriteSearch(term string, index int) error {
-	c.Search.Term = term
-	c.Search.Index = index
-	return nil
-}
-
-func (c *testConfig) ReadPins() (map[string]string, error) {
-	return c.Pins, nil
-}
-
-func (c *testConfig) FindPin(term string) (string, bool) {
-	return c.Pin, c.Pin != ""
-}
-
-func (c *testConfig) WritePin(_, value string) error {
-	c.Pin = value
-	return nil
-}
-
-func (c *testConfig) RemovePin(term string) error {
-	c.Pin = ""
-	return nil
-}
-
 func TestGuess_Autojump(t *testing.T) {
-	imp := Guess("autojump", &testConfig{})
+	imp := Guess("autojump", &config.Testing{})
 
 	_, ok := imp.(*autojump)
 	assert.True(t, ok)
 }
 
 func TestGuess_Z(t *testing.T) {
-	imp := Guess("z", &testConfig{})
+	imp := Guess("z", &config.Testing{})
 
 	_, ok := imp.(*z)
 	assert.True(t, ok)
 }
 
 func TestGuess_Both(t *testing.T) {
-	imp := Guess("", &testConfig{})
+	imp := Guess("", &config.Testing{})
 
 	_, ok := imp.(multiImporter)
 	assert.True(t, ok)

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -1,0 +1,60 @@
+package importer
+
+import (
+	"os"
+	"path"
+
+	"github.com/gsamokovarov/jump/config"
+	"github.com/gsamokovarov/jump/scoring"
+)
+
+var td string
+
+type testConfig struct {
+	Entries scoring.Entries
+	Search  config.Search
+	Pins    map[string]string
+	Pin     string
+}
+
+func (c *testConfig) ReadEntries() (scoring.Entries, error) {
+	return c.Entries, nil
+}
+
+func (c *testConfig) WriteEntries(entries scoring.Entries) error {
+	c.Entries = entries
+	return nil
+}
+
+func (c *testConfig) ReadSearch() config.Search {
+	return c.Search
+}
+
+func (c *testConfig) WriteSearch(term string, index int) error {
+	c.Search.Term = term
+	c.Search.Index = index
+	return nil
+}
+
+func (c *testConfig) ReadPins() (map[string]string, error) {
+	return c.Pins, nil
+}
+
+func (c *testConfig) FindPin(term string) (string, bool) {
+	return c.Pin, c.Pin != ""
+}
+
+func (c *testConfig) WritePin(_, value string) error {
+	c.Pin = value
+	return nil
+}
+
+func (c *testConfig) RemovePin(term string) error {
+	c.Pin = ""
+	return nil
+}
+
+func init() {
+	cwd, _ := os.Getwd()
+	td = path.Join(cwd, "testdata")
+}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -78,6 +78,13 @@ func TestGuess_Both(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestCallback(t *testing.T) {
+	var fn Callback
+
+	// Does not crash when fn is nil.
+	fn.Call(nil)
+}
+
 func init() {
 	cwd, _ := os.Getwd()
 	td = path.Join(cwd, "testdata")

--- a/importer/multi.go
+++ b/importer/multi.go
@@ -10,7 +10,7 @@ func (mi multiImporter) Import(fn Callback) error {
 
 	for _, i := range mi {
 		err := i.Import(fn)
-		if err == UnsupportedErr {
+		if err == NotFoundErr {
 			continue
 		}
 		if err != nil {

--- a/importer/multi.go
+++ b/importer/multi.go
@@ -1,0 +1,28 @@
+package importer
+
+// multiImporter tries to import configurations from multiple importers. If at
+// least on of the importers succeed, no errors will be returned.
+type multiImporter []Importer
+
+func (mi multiImporter) Import(fn Callback) error {
+	var lastErr error
+	atLeastOneSucceeded := false
+
+	for _, i := range mi {
+		err := i.Import(fn)
+		if err == UnsupportedErr {
+			continue
+		}
+		if err != nil {
+			lastErr = err
+		}
+
+		atLeastOneSucceeded = true
+	}
+
+	if !atLeastOneSucceeded && lastErr != nil {
+		return lastErr
+	}
+
+	return nil
+}

--- a/importer/multi_test.go
+++ b/importer/multi_test.go
@@ -1,0 +1,44 @@
+package importer
+
+import (
+	"errors"
+	p "path"
+	"testing"
+
+	"github.com/gsamokovarov/assert"
+)
+
+type failingImporter struct{}
+
+func (failingImporter) Import(Callback) error { return errors.New("importer: failing") }
+
+func Test_multiImporter(t *testing.T) {
+	conf := &testConfig{}
+	autojumpPath := p.Join(td, "autojump.txt")
+	zPath := p.Join(td, "z")
+
+	imp := multiImporter{
+		Autojump(conf, autojumpPath),
+		Z(conf, zPath),
+	}
+
+	err := imp.Import(nil)
+	assert.Nil(t, err)
+
+	assert.Len(t, 8, conf.Entries)
+}
+
+func Test_multiImporter_oneErrored(t *testing.T) {
+	conf := &testConfig{}
+	autojumpPath := p.Join(td, "autojump.txt")
+
+	imp := multiImporter{
+		failingImporter{},
+		Autojump(conf, autojumpPath),
+	}
+
+	err := imp.Import(nil)
+	assert.Nil(t, err)
+
+	assert.Len(t, 6, conf.Entries)
+}

--- a/importer/multi_test.go
+++ b/importer/multi_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gsamokovarov/assert"
+	"github.com/gsamokovarov/jump/config"
 )
 
 type failingImporter struct{}
@@ -13,7 +14,7 @@ type failingImporter struct{}
 func (failingImporter) Import(Callback) error { return errors.New("importer: failing") }
 
 func Test_multiImporter(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 	autojumpPath := p.Join(td, "autojump.txt")
 	zPath := p.Join(td, "z")
 
@@ -29,7 +30,7 @@ func Test_multiImporter(t *testing.T) {
 }
 
 func Test_multiImporter_oneErrored(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 	autojumpPath := p.Join(td, "autojump.txt")
 
 	imp := multiImporter{

--- a/importer/testdata/autojump.txt
+++ b/importer/testdata/autojump.txt
@@ -1,0 +1,6 @@
+38.729833462	/Users/genadi/Development/jump
+14.1421356237	/Users/genadi/Development/mock_last_status
+33.1662479035	/Users/genadi/Development
+14.1421356237	/Users/genadi/.go/src/github.com/gsamokovarov/jump
+43.5889894353	/usr/local/Cellar/autojump
+20.0	/Users/genadi/Development/gloat

--- a/importer/testdata/z
+++ b/importer/testdata/z
@@ -1,0 +1,4 @@
+/Users/genadi/Development/hack|11|1536272816
+/Users/genadi/Development/masse|1|1536272502
+/Users/genadi/Development|3|1536272506
+/Users/genadi/.go/src/github.com/gsamokovarov/jump|1|1536272492

--- a/importer/z.go
+++ b/importer/z.go
@@ -48,9 +48,7 @@ func (i *z) Import(fn Callback) error {
 			continue
 		}
 
-		if fn != nil {
-			fn(entry)
-		}
+		fn.Call(entry)
 
 		jumpEntries = append(jumpEntries, entry)
 	}

--- a/importer/z_test.go
+++ b/importer/z_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/gsamokovarov/assert"
+	"github.com/gsamokovarov/jump/config"
 )
 
 func TestZ(t *testing.T) {
-	conf := &testConfig{}
+	conf := &config.Testing{}
 	configPath := p.Join(td, "z")
 
 	imp := Z(conf, configPath)

--- a/importer/z_test.go
+++ b/importer/z_test.go
@@ -1,0 +1,42 @@
+package importer
+
+import (
+	p "path"
+	"testing"
+	"time"
+
+	"github.com/gsamokovarov/assert"
+)
+
+func TestZ(t *testing.T) {
+	conf := &testConfig{}
+	configPath := p.Join(td, "z")
+
+	imp := Z(conf, configPath)
+
+	err := imp.Import(nil)
+	assert.Nil(t, err)
+
+	assert.
+		Len(t, 4, conf.Entries).
+		// 0
+		Equal(t, "/Users/genadi/.go/src/github.com/gsamokovarov/jump", conf.Entries[0].Path).
+		Equal(t, 1, conf.Entries[0].Score.Weight).
+		Equal(t, time.Unix(1536272492, 0), conf.Entries[0].Score.Age).
+		// 1
+		Equal(t, "/Users/genadi/Development/masse", conf.Entries[1].Path).
+		Equal(t, 1, conf.Entries[1].Score.Weight).
+		Equal(t, time.Unix(1536272502, 0), conf.Entries[1].Score.Age).
+		// 2
+		Equal(t, "/Users/genadi/Development", conf.Entries[2].Path).
+		Equal(t, 3, conf.Entries[2].Score.Weight).
+		Equal(t, time.Unix(1536272506, 0), conf.Entries[2].Score.Age).
+		// 3
+		Equal(t, "/Users/genadi/Development/hack", conf.Entries[3].Path).
+		Equal(t, 11, conf.Entries[3].Score.Weight).
+		Equal(t, time.Unix(1536272816, 0), conf.Entries[3].Score.Age)
+
+	for i, j := 0, 1; i < len(conf.Entries)-1; i, j = i+1, j+1 {
+		assert.True(t, conf.Entries[i].CalculateScore() <= conf.Entries[j].CalculateScore())
+	}
+}

--- a/scoring/entry.go
+++ b/scoring/entry.go
@@ -27,3 +27,11 @@ func (e *Entry) String() string {
 func NewEntry(path string) *Entry {
 	return &Entry{path, NewScore()}
 }
+
+// NewEntryWithWeight creates a new entry with the specified path and weight.
+func NewEntryWithWeight(path string, weight int64) *Entry {
+	score := NewScore()
+	score.Weight = weight
+
+	return &Entry{path, score}
+}

--- a/scoring/entry.go
+++ b/scoring/entry.go
@@ -27,11 +27,3 @@ func (e *Entry) String() string {
 func NewEntry(path string) *Entry {
 	return &Entry{path, NewScore()}
 }
-
-// NewEntryWithWeight creates a new entry with the specified path and weight.
-func NewEntryWithWeight(path string, weight int64) *Entry {
-	score := NewScore()
-	score.Weight = weight
-
-	return &Entry{path, score}
-}

--- a/scoring/entry_test.go
+++ b/scoring/entry_test.go
@@ -18,10 +18,3 @@ func TestEntriesUpdateScore(t *testing.T) {
 
 	assert.Equal(t, 2, entry.Score.Weight)
 }
-
-func TestNewEntriesWithWeight(t *testing.T) {
-	entry := NewEntryWithWeight("/foo", 2)
-
-	assert.Equal(t, "/foo", entry.Path)
-	assert.Equal(t, 2, entry.Score.Weight)
-}

--- a/scoring/entry_test.go
+++ b/scoring/entry_test.go
@@ -18,3 +18,10 @@ func TestEntriesUpdateScore(t *testing.T) {
 
 	assert.Equal(t, 2, entry.Score.Weight)
 }
+
+func TestNewEntriesWithWeight(t *testing.T) {
+	entry := NewEntryWithWeight("/foo", 2)
+
+	assert.Equal(t, "/foo", entry.Path)
+	assert.Equal(t, 2, entry.Score.Weight)
+}


### PR DESCRIPTION
Seeing that there is interest for `autojump` and `z` importers in #23 , I'm starting this change to track the future configuration importers.

For `0.21.0`, I'm going to introduce the `jump import` command that can automatically import already existing `autojump` or `z` scores.

Currently, only `autojump` is supported and it works like so:

```bash
› jump import
Importing /Users/genadi/Development/jump
Importing /Users/genadi/Development/mock_last_status
Importing /usr/local/Cellar/autojump
Importing /Users/genadi/Development/gloat
```

This command is best run on a fresh database, because of the different score units jump and autojump/z have. The importers won't try to import any already existing paths, so it's safe to run on an active jump database, having in mind that the new directory entries may have better or worse scores related to their search peers in jump, because of the aforementioned score units.

--- 

The z configuration importer is still in the works.