### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ below in needs to be in `~/.bashrc`, `~/bash_profile` or `~/.zshrc`:
 
 For fish shell, put the line below needs to be in `~/.config/fish/config.fish`:
 
-    status --is-interactive; and . (jump shell | psub)
+    status --is-interactive; and source (jump shell fish | psub)
 
 Once integrated, jump will automatically monitor directory changes and start
 building an internal database.


### PR DESCRIPTION
Changed fish shell integration command to `status --is-interactive; and source (jump shell fish | psub)` as the previous command `status --is-interactive; and . (jump shell | psub)` does not work in fish 3.0.2

The `status --is-interactive; and source (jump shell fish | psub)` command is taken from `jump shell fish` output.