### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: bionic
 language: go
 
 go:
-  - 1.13
+  - 1.13.x
   - master
 
 script:
@@ -13,6 +14,3 @@ matrix:
   allow_failures:
     - go: master
 
-env:
-  global:
-    - GO111MODULE=on


### PR DESCRIPTION
- Use dist: bionic
- Update go env to 1.13.x (this would allow travis to pick latest 1.13 line)
- Remove GO111MODULE, as it is default on

Relates to https://github.com/Homebrew/homebrew-core/pull/49592 (homebrew side shipped with latest go version)