### PR TITLE
build(make): add build target for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ build.linux:
 build.linux.arm:
 	@env GOOS=linux GOARCH=arm go build -o jump
 
+.PHONY: build.windows
+build.windows:
+	@env GOOS=windows GOARCH=amd64 go build -o jump.exe
+
 .PHONY: test
 test:
 	@rm -rf ./config/testdata/.tmp*


### PR DESCRIPTION
jump works surprisingly well on nix-like environment on windows, specifically msys2 (and potentially others I have not tried). This PR attempts to add build target for windows for those environment, in a hope release can include prebuilt binaries for windows as well. 

since init script requires bash compatible shell, I expect compiled binary won't work on plain cmd though compiled binary itself runs fine on cmd.