### PR TITLE
Update fish setup in man pages

### DIFF
--- a/man/j.1
+++ b/man/j.1
@@ -32,7 +32,7 @@ For fish shell, put the line below needs to be in \fB~/\.config/fish/config\.fis
 .
 .nf
 
-status \-\-is\-interactive; and \. (jump shell | psub)
+status \-\-is\-interactive; and source (jump shell fish | psub)
 .
 .fi
 .

--- a/man/jump.1
+++ b/man/jump.1
@@ -32,7 +32,7 @@ For fish shell, put the line below needs to be in \fB~/\.config/fish/config\.fis
 .
 .nf
 
-status \-\-is\-interactive; and \. (jump shell | psub)
+status \-\-is\-interactive; and source (jump shell fish | psub)
 .
 .fi
 .

--- a/man/jump.1.ronn
+++ b/man/jump.1.ronn
@@ -20,7 +20,7 @@ below in needs to be in `~/.bashrc`, `~/bash_profile` or `~/.zshrc`:
 
 For fish shell, put the line below needs to be in `~/.config/fish/config.fish`:
 
-    status --is-interactive; and . (jump shell | psub)
+    status --is-interactive; and source (jump shell fish | psub)
 
 Once integrated, **jump** will automatically directory changes and start
 building an internal database.


### PR DESCRIPTION
The config snippet was updated on the README.md in 8995bd85df443b5ea072d46102f7717505993926 but
still had the old snippet in man pages. 

Using the old snippet was causing a warning with fish 3.1.0 like the one described in fish-shell/fish-shell#6613 👇 

```
source: Error encountered while sourcing file '/var/folders/4c/d7j6xq4d7flbhnn8_4l37p9h0000gn/T//.psub.LADwQVnrnr':
source: No such file or directory
```