### PR TITLE
Add reference to official Void package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Jump comes in packages for the following platforms.
 | macOS | `brew install jump` |
 | Ubuntu | `wget https://github.com/gsamokovarov/jump/releases/download/v0.40.0/jump_0.40.0_amd64.deb && sudo dpkg -i jump_0.40.0_amd64.deb` |
 | Fedora | `wget https://github.com/gsamokovarov/jump/releases/download/v0.40.0/jump-0.40.0-1.x86_64.rpm && sudo rpm -i jump-0.40.0-1.x86_64.rpm` |
+| Void | `xbps-install -S jump` |
 | Nix | `nix-env -iA nixpkgs.jump` |
 | Go | `go get github.com/gsamokovarov/jump` |
 


### PR DESCRIPTION
This adds a reference to the official [Void Linux](https://voidlinux.org/) package within the README.