### PR TITLE
Update installation instructions for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Jump comes in packages for the following platforms.
 | Fedora | `wget https://github.com/gsamokovarov/jump/releases/download/v0.40.0/jump-0.40.0-1.x86_64.rpm && sudo rpm -i jump-0.40.0-1.x86_64.rpm` |
 | Void | `xbps-install -S jump` |
 | Nix | `nix-env -iA nixpkgs.jump` |
-| Go | `go get github.com/gsamokovarov/jump` |
+| Go | `go install github.com/gsamokovarov/jump@latest` |
 
 ### Integration
 


### PR DESCRIPTION
Starting from Go 1.17, installing executables with `go get` is deprecated.
In Go 1.18, `go get` doesn't build packages.
See https://go.dev/doc/go-get-install-deprecation for reference.