### PR TITLE
add instructions for Murex shell bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Invoke-Expression (&jump shell pwsh | Out-String)
 Once integrated, jump will automatically monitor directory changes and start
 building an internal database.
 
+#### Murex
+
+Jump bindings can be installed directly from Murex:
+
+```
+murex-package install https://github.com/lmorg/murex-module-jump.git
+```
+
+Please note that this doesn't install `jump` itself. You will still need to
+install the `jump` executable via the installation instructions above.
+
 ### But `j` is not my favourite letter!
 
 This is fine, you can bind jump to `z` with the following integration command:


### PR DESCRIPTION
There was a [support request](https://github.com/lmorg/murex/issues/635) raised on the Murex shell's project page about integrating `jump` support. So the following module was created: https://github.com/lmorg/murex-module-jump

This can be installed automatically via Murex's package manager:
```
murex-package install https://github.com/lmorg/murex-module-jump.git
```