### PR TITLE
fish: leave a clean exit status after z/j jumps

### DIFF
--- a/shell/integration.fish
+++ b/shell/integration.fish
@@ -38,8 +38,9 @@ function __jump_cd
 
     status --is-command-substitution; and return
     set -g dirprev $dirprev[-24..-1] $previous
-    set -e dirnext
+    set -q dirnext; and set -e dirnext
     set -g __fish_cd_direction prev
+    true
 end
 
 function {{.Bind}}


### PR DESCRIPTION
@gsamokovarov - was just testing out the fish changes a little further locally and noticed that while `z` was working, it was setting an exit code of `1` (error). Figured I ought to send a patch upstream.

Claude came up with the description below:

---

__jump_cd's last two lines were both plain `set -g` assignments, which per fish's set builtin do not reset $status on success (preserve_failure_exit_status is only cleared by -e/-q/-n/-S). So whatever status came before them - notably `set -e dirnext` erasing a variable that was never set (status 4), or the new `set -q dirnext` guard (status 1) - leaked out as the exit status of the whole z/j invocation, even though the directory change itself succeeded every time.

Guard the erase and add an explicit `true` to reset status before the function returns.